### PR TITLE
Force codepage to 437, even in international (non-US) Windows installations

### DIFF
--- a/CustomActionFastMsi/CustomAction.cs
+++ b/CustomActionFastMsi/CustomAction.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.IO;
+﻿using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.Deployment.WindowsInstaller;
-using ICSharpCode.SharpZipLib.Zip;
-using ICSharpCode.SharpZipLib.Core;
+using System.Diagnostics;
+using System.IO;
 
 namespace CustomActionFastMsi
 {
@@ -36,11 +33,19 @@ namespace CustomActionFastMsi
 
             var fastzip = new FastZip();
 
+            // Force zip library to use codepage 437 (IBM PC US) rather than autodetecting the system codepage.
+            // ref: http://community.sharpdevelop.net/forums/t/19065.aspx
+            // ref: https://stackoverflow.com/questions/46950386/sharpziplib-1-is-not-a-supported-code-page
+            ZipConstants.DefaultCodePage = 437;
+
             session.Log("Starting extraction");
 
+            var stopWatch = new Stopwatch();
+            stopWatch.Start();
             fastzip.ExtractZip(zipFile, Path.Combine(targetDir, appName), null);
+            stopWatch.Stop();
 
-            session.Log("Finished extraction");
+            session.Log(string.Format("Finished extraction (time taken: {0} ms)", stopWatch.ElapsedMilliseconds));
 
             File.Delete(zipFile);
 

--- a/CustomActionFastMsi/CustomActionFastMsi.csproj
+++ b/CustomActionFastMsi/CustomActionFastMsi.csproj
@@ -37,9 +37,6 @@
       <HintPath>ext\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.Deployment.WindowsInstaller">
       <Private>True</Private>


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

This fixes related ChefDK installer issue: https://github.com/chef/chef-dk/issues/1290 by forcing the zip library used in our installer to use the US (437) codepage rather than having the Encoding determined by the OEM codepage of the target system.

Additionally, timing information has been added to the logging to aid diagnosis of slow decompression operations.