### PR TITLE
adding bldr.toml

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,0 +1,5 @@
+[CustomActionFastMsi]
+build_targets = [
+  "x86_64-windows"
+]
+plan_path = "habitat"


### PR DESCRIPTION
I have a feeling I need the .bldr.toml in order to tell it this is a windows build.

Signed-off-by: mwrock <matt@mattwrock.com>
