### PR TITLE
Add a parameter to override the zip file name

### DIFF
--- a/CustomActionFastMsi/CustomAction.cs
+++ b/CustomActionFastMsi/CustomAction.cs
@@ -19,6 +19,7 @@ namespace CustomActionFastMsi
             string assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             string targetDir = session.CustomActionData["FASTZIPDIR"];
             string appName = session.CustomActionData["FASTZIPAPPNAME"];
+            string zipName = session.CustomActionData["FASTZIPNAME"];
 
             session.Log("FASTZIPDIR = " + targetDir);
             session.Log("FASTZIPAPPNAME = " + appName);
@@ -30,6 +31,11 @@ namespace CustomActionFastMsi
             }
 
             string zipFile = Path.Combine(targetDir, appName + ".zip");
+            if (zipName != null)
+            {
+                session.Log("FASTZIPNAME = " + zipName);
+                zipFile = Path.Combine(targetDir, zipName + ".zip");
+            }
             if (!File.Exists(zipFile))
             {
                 session.Log("Zip file does not exist - ignoring");


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

The current logic to determine the `zipFile` path is targetDir + appName + .zip. The problem for chef-foundation is that the zip file is named `chef-foundation.zip` but the appName is `chef`. Therefore this dll builds a zipFile path C:\opscode\chef.zip when it needs to be C:\opscode\chef-foundation.zip. This PR adds a parameter to support this use case.

BTW the reason why chef-foundation installs to C:\opscode\chef is so all the linked libraries and shebangs work properly when chef-client gets built from the chef-foundation project

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
